### PR TITLE
Use new handlebars loader instead of handlebars-template-loader which is abandoned

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Handlebars = require('handlebars');
-var HandlebarsTemplateLoader = require('handlebars-template-loader');
+var HandlebarsTemplateLoader = require('handlebars-loader');
 
 var pathForHandlebarsRuntime = require.resolve('handlebars/runtime');
 var pathForHandlebars = require.resolve('handlebars');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "handlebars-loader",
     "webpack"
   ],
+  "peerDependencies": {
+    "handlebars": "^2.0.0",
+    "handlebars-loader": "^1.7.3"
+  },
   "author": "Bizzabo",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bizzabo-handlebars-loader",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Webpack loader with handlebars (including runtime + compiler)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Among other things, this will remove the 0.x json5 dependency which is vulnerable and has no compatible patched version.